### PR TITLE
Fix for link sdk assemblies only on iOS

### DIFF
--- a/RoundedBoxView/RoundedBoxView/RoundedBoxView.Forms.Plugin.iOSUnified/RoundedBoxViewImplementation.cs
+++ b/RoundedBoxView/RoundedBoxView/RoundedBoxView.Forms.Plugin.iOSUnified/RoundedBoxViewImplementation.cs
@@ -3,6 +3,8 @@ using RoundedBoxView.Forms.Plugin.iOSUnified;
 using RoundedBoxView.Forms.Plugin.iOSUnified.ExtensionMethods;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
+using Foundation;
+using System;
 
 [assembly:
   ExportRenderer(typeof (RoundedBoxView.Forms.Plugin.Abstractions.RoundedBoxView), typeof (RoundedBoxViewRenderer))]
@@ -12,6 +14,7 @@ namespace RoundedBoxView.Forms.Plugin.iOSUnified
   /// <summary>
   ///   Source From : https://gist.github.com/rudyryk/8cbe067a1363b45351f6
   /// </summary>
+  [Preserve(AllMembers = true)]
   public class RoundedBoxViewRenderer : BoxRenderer
   {
     /// <summary>
@@ -19,6 +22,7 @@ namespace RoundedBoxView.Forms.Plugin.iOSUnified
     /// </summary>
     public static void Init()
     {
+		var temp = DateTime.Now;
     }
 
     private Abstractions.RoundedBoxView _formControl


### PR DESCRIPTION
Quick fix for Release/Ad-hoc builds not working when `Link SDK assemblies only` is selected.