### PR TITLE
Disabled Shiftup for Picker controls and Xamarin Forms update

### DIFF
--- a/KeyboardOverlap/KeyboardOverlap/KeyboardOverlap.Forms.Plugin.iOSUnified/KeyboardOverlap.Forms.Plugin.iOSUnified.csproj
+++ b/KeyboardOverlap/KeyboardOverlap/KeyboardOverlap.Forms.Plugin.iOSUnified/KeyboardOverlap.Forms.Plugin.iOSUnified.csproj
@@ -44,25 +44,25 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
-    <Reference Include="Xamarin.Forms.Platform.iOS">
-      <HintPath>..\..\packages\Xamarin.Forms.2.0.0.6490\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.2.0.0.6490\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.2.0.0.6490\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.2.0.0.6490\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform.iOS">
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml">
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Import Project="..\..\packages\Xamarin.Forms.2.0.0.6490\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.0.0.6490\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   <ItemGroup>
     <Folder Include="Extensions\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <Import Project="..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/KeyboardOverlap/KeyboardOverlap/KeyboardOverlap.Forms.Plugin.iOSUnified/KeyboardOverlapRenderer.cs
+++ b/KeyboardOverlap/KeyboardOverlap/KeyboardOverlap.Forms.Plugin.iOSUnified/KeyboardOverlapRenderer.cs
@@ -7,134 +7,137 @@ using CoreGraphics;
 using KeyboardOverlap.Forms.Plugin.iOSUnified;
 using System.Diagnostics;
 
-[assembly: ExportRenderer (typeof(Page), typeof(KeyboardOverlapRenderer))]
+[assembly: ExportRenderer(typeof(Page), typeof(KeyboardOverlapRenderer))]
 namespace KeyboardOverlap.Forms.Plugin.iOSUnified
 {
-	[Preserve (AllMembers = true)]
-	public class KeyboardOverlapRenderer : PageRenderer
-	{
-		NSObject _keyboardShowObserver;
-		NSObject _keyboardHideObserver;
-		private bool _pageWasShiftedUp;
-		private double _activeViewBottom;
-		private bool _isKeyboardShown;
+    [Preserve(AllMembers = true)]
+    public class KeyboardOverlapRenderer : PageRenderer
+    {
+        NSObject _keyboardShowObserver;
+        NSObject _keyboardHideObserver;
+        private bool _pageWasShiftedUp;
+        private double _activeViewBottom;
+        private bool _isKeyboardShown;
 
-		public static void Init ()
-		{
-			var now = DateTime.Now;
-			Debug.WriteLine ("Keyboard Overlap plugin initialized {0}", now);
-		}
+        public static void Init()
+        {
+            var now = DateTime.Now;
+            Debug.WriteLine("Keyboard Overlap plugin initialized {0}", now);
+        }
 
-		public override void ViewWillAppear (bool animated)
-		{
-			base.ViewWillAppear (animated);
+        public override void ViewWillAppear(bool animated)
+        {
+            base.ViewWillAppear(animated);
 
-			var page = Element as ContentPage;
+            var page = Element as ContentPage;
 
 			if (page != null) {
-				var contentScrollView = page.Content as ScrollView;
+                var contentScrollView = page.Content as ScrollView;
 
-				if (contentScrollView != null)
-					return;
+                if (contentScrollView != null)
+                    return;
 
-				RegisterForKeyboardNotifications ();
-			}
-		}
+                RegisterForKeyboardNotifications();
+            }
+        }
 
-		public override void ViewWillDisappear (bool animated)
-		{
-			base.ViewWillDisappear (animated);
+        public override void ViewWillDisappear(bool animated)
+        {
+            base.ViewWillDisappear(animated);
 
-			UnregisterForKeyboardNotifications ();
-		}
+            UnregisterForKeyboardNotifications();
+        }
 
-		void RegisterForKeyboardNotifications ()
-		{
-			if (_keyboardShowObserver == null)
-				_keyboardShowObserver = NSNotificationCenter.DefaultCenter.AddObserver (UIKeyboard.WillShowNotification, OnKeyboardShow);
-			if (_keyboardHideObserver == null)
-				_keyboardHideObserver = NSNotificationCenter.DefaultCenter.AddObserver (UIKeyboard.WillHideNotification, OnKeyboardHide);
-		}
+        void RegisterForKeyboardNotifications()
+        {
+            if (_keyboardShowObserver == null)
+                _keyboardShowObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.WillShowNotification, OnKeyboardShow);
+            if (_keyboardHideObserver == null)
+                _keyboardHideObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.WillHideNotification, OnKeyboardHide);
+        }
 
-		void UnregisterForKeyboardNotifications ()
-		{
-			_isKeyboardShown = false;
+        void UnregisterForKeyboardNotifications()
+        {
+            _isKeyboardShown = false;
 			if (_keyboardShowObserver != null) {
-				NSNotificationCenter.DefaultCenter.RemoveObserver (_keyboardShowObserver);
-				_keyboardShowObserver.Dispose ();
-				_keyboardShowObserver = null;
-			}
+                NSNotificationCenter.DefaultCenter.RemoveObserver(_keyboardShowObserver);
+                _keyboardShowObserver.Dispose();
+                _keyboardShowObserver = null;
+            }
 
 			if (_keyboardHideObserver != null) {
-				NSNotificationCenter.DefaultCenter.RemoveObserver (_keyboardHideObserver);
-				_keyboardHideObserver.Dispose ();
-				_keyboardHideObserver = null;
-			}
-		}
+                NSNotificationCenter.DefaultCenter.RemoveObserver(_keyboardHideObserver);
+                _keyboardHideObserver.Dispose();
+                _keyboardHideObserver = null;
+            }
+        }
 
-		protected virtual void OnKeyboardShow (NSNotification notification)
-		{
-			if (!IsViewLoaded || _isKeyboardShown)
-				return;
+        protected virtual void OnKeyboardShow(NSNotification notification)
+        {
+            if (!IsViewLoaded || _isKeyboardShown)
+                return;
 
-			_isKeyboardShown = true;
-			var activeView = View.FindFirstResponder ();
+            _isKeyboardShown = true;
+            var activeView = View.FindFirstResponder();
 
-			if (activeView == null)
-				return;
+            if (activeView == null)
+                return;
 
-			var keyboardFrame = UIKeyboard.FrameEndFromNotification (notification);
-			var isOverlapping = activeView.IsKeyboardOverlapping (View, keyboardFrame);
+            if (activeView.Superview.GetType().Name == nameof(PickerRenderer)) //Picker already shifts layout, so this prevents any shifting issues with UIPickers.
+                return;
 
-			if (!isOverlapping)
-				return;
+            var keyboardFrame = UIKeyboard.FrameEndFromNotification(notification);
+            var isOverlapping = activeView.IsKeyboardOverlapping(View, keyboardFrame);
+
+            if (!isOverlapping)
+                return;
 
 			if (isOverlapping) {
-				_activeViewBottom = activeView.GetViewRelativeBottom (View);
-				ShiftPageUp (keyboardFrame.Height, _activeViewBottom);
-			}
-		}
+                _activeViewBottom = activeView.GetViewRelativeBottom(View);
+                ShiftPageUp(keyboardFrame.Height, _activeViewBottom);
+            }
+        }
 
-		private void OnKeyboardHide (NSNotification notification)
-		{
-			if (!IsViewLoaded)
-				return;
+        private void OnKeyboardHide(NSNotification notification)
+        {
+            if (!IsViewLoaded)
+                return;
 
-			_isKeyboardShown = false;
-			var keyboardFrame = UIKeyboard.FrameEndFromNotification (notification);
+            _isKeyboardShown = false;
+            var keyboardFrame = UIKeyboard.FrameEndFromNotification(notification);
 
 			if (_pageWasShiftedUp) {
-				ShiftPageDown (keyboardFrame.Height, _activeViewBottom);
-			}
-		}
+                ShiftPageDown(keyboardFrame.Height, _activeViewBottom);
+            }
+        }
 
-		private void ShiftPageUp (nfloat keyboardHeight, double activeViewBottom)
-		{
-			var pageFrame = Element.Bounds;
+        private void ShiftPageUp(nfloat keyboardHeight, double activeViewBottom)
+        {
+            var pageFrame = Element.Bounds;
 
-			var newY = pageFrame.Y + CalculateShiftByAmount (pageFrame.Height, keyboardHeight, activeViewBottom);
+            var newY = pageFrame.Y + CalculateShiftByAmount(pageFrame.Height, keyboardHeight, activeViewBottom);
 
-			Element.LayoutTo (new Rectangle (pageFrame.X, newY,
-				pageFrame.Width, pageFrame.Height));
+            Element.LayoutTo (new Rectangle (pageFrame.X, newY,
+                pageFrame.Width, pageFrame.Height));
 
-			_pageWasShiftedUp = true;
-		}
+            _pageWasShiftedUp = true;
+        }
 
-		private void ShiftPageDown (nfloat keyboardHeight, double activeViewBottom)
-		{
-			var pageFrame = Element.Bounds;
+        private void ShiftPageDown (nfloat keyboardHeight, double activeViewBottom)
+        {
+            var pageFrame = Element.Bounds;
 
-			var newY = pageFrame.Y - CalculateShiftByAmount (pageFrame.Height, keyboardHeight, activeViewBottom);
+            var newY = pageFrame.Y - CalculateShiftByAmount(pageFrame.Height, keyboardHeight, activeViewBottom);
 
-			Element.LayoutTo (new Rectangle (pageFrame.X, newY,
-				pageFrame.Width, pageFrame.Height));
+            Element.LayoutTo (new Rectangle (pageFrame.X, newY,
+                pageFrame.Width, pageFrame.Height));
 
-			_pageWasShiftedUp = false;
-		}
+            _pageWasShiftedUp = false;
+        }
 
-		private double CalculateShiftByAmount (double pageHeight, nfloat keyboardHeight, double activeViewBottom)
-		{
-			return (pageHeight - activeViewBottom) - keyboardHeight;
-		}
-	}
+        private double CalculateShiftByAmount (double pageHeight, nfloat keyboardHeight, double activeViewBottom)
+        {
+            return (pageHeight - activeViewBottom) - keyboardHeight;
+        }
+    }
 }

--- a/KeyboardOverlap/KeyboardOverlap/KeyboardOverlap.Forms.Plugin.iOSUnified/packages.config
+++ b/KeyboardOverlap/KeyboardOverlap/KeyboardOverlap.Forms.Plugin.iOSUnified/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.0.0.6490" targetFramework="xamarinios10" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="xamarinios10" />
 </packages>

--- a/KeyboardOverlap/SampleApp/SampleApp.iOS/SampleApp.iOS.csproj
+++ b/KeyboardOverlap/SampleApp/SampleApp.iOS/SampleApp.iOS.csproj
@@ -249,19 +249,19 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
-    <Reference Include="Xamarin.Forms.Platform.iOS">
-      <HintPath>..\..\packages\Xamarin.Forms.2.0.0.6490\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.2.0.0.6490\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.2.0.0.6490\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.2.0.0.6490\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform.iOS">
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml">
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Import Project="..\..\packages\Xamarin.Forms.2.0.0.6490\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.0.0.6490\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/KeyboardOverlap/SampleApp/SampleApp.iOS/packages.config
+++ b/KeyboardOverlap/SampleApp/SampleApp.iOS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.0.0.6490" targetFramework="xamarinios10" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="xamarinios10" />
 </packages>

--- a/KeyboardOverlap/SampleApp/SampleApp/SampleApp.csproj
+++ b/KeyboardOverlap/SampleApp/SampleApp/SampleApp.csproj
@@ -163,16 +163,17 @@
   -->
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.2.0.0.6490\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.2.0.0.6490\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.2.0.0.6490\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml">
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <Import Project="..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/KeyboardOverlap/SampleApp/SampleApp/packages.config
+++ b/KeyboardOverlap/SampleApp/SampleApp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.0.0.6490" targetFramework="portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="portable45-net45+win8+wp8" />
 </packages>


### PR DESCRIPTION
I just added a workaround for Pickers (UIPicker) because when a value is selected, it changes layout twice, so when keyboard is hiding the layout is shiftdown more than it should be.

Also updated to latest stable version of Xamarin Forms