### PR TITLE
Fix iOS 11 The First Time keyboard blocking the Entry

### DIFF
--- a/KeyboardOverlap/KeyboardOverlap/KeyboardOverlap.Forms.Plugin.iOSUnified/KeyboardOverlapRenderer.cs
+++ b/KeyboardOverlap/KeyboardOverlap/KeyboardOverlap.Forms.Plugin.iOSUnified/KeyboardOverlapRenderer.cs
@@ -17,7 +17,6 @@ namespace KeyboardOverlap.Forms.Plugin.iOSUnified
 		NSObject _keyboardHideObserver;
 		private bool _pageWasShiftedUp;
 		private double _activeViewBottom;
-		private bool _isKeyboardShown;
 
 		public static void Init ()
 		{
@@ -58,7 +57,6 @@ namespace KeyboardOverlap.Forms.Plugin.iOSUnified
 
 		void UnregisterForKeyboardNotifications ()
 		{
-			_isKeyboardShown = false;
 			if (_keyboardShowObserver != null) {
 				NSNotificationCenter.DefaultCenter.RemoveObserver (_keyboardShowObserver);
 				_keyboardShowObserver.Dispose ();
@@ -74,10 +72,9 @@ namespace KeyboardOverlap.Forms.Plugin.iOSUnified
 
 		protected virtual void OnKeyboardShow (NSNotification notification)
 		{
-			if (!IsViewLoaded || _isKeyboardShown)
+			if (!IsViewLoaded)
 				return;
 
-			_isKeyboardShown = true;
 			var activeView = View.FindFirstResponder ();
 
 			if (activeView == null)
@@ -100,7 +97,6 @@ namespace KeyboardOverlap.Forms.Plugin.iOSUnified
 			if (!IsViewLoaded)
 				return;
 
-			_isKeyboardShown = false;
 			var keyboardFrame = UIKeyboard.FrameEndFromNotification (notification);
 
 			if (_pageWasShiftedUp) {


### PR DESCRIPTION
Fix iOS 11  The First Time keyboard blocking the Entry, The first time you get a wrong keyboard height

https://developer.apple.com/library/content/documentation/StringsTextFonts/Conceptual/TextAndWebiPhoneOS/RevisionHistory.html#//apple_ref/doc/uid/TP40009542-CH99-SW1