### PR TITLE
Bugfix for issue #164 Android: Crash with ObjectDisposedException when image is replaced very fast

### DIFF
--- a/SVG/SVG/SVG.Forms.Plugin.Android/SvgImageRenderer.cs
+++ b/SVG/SVG/SVG.Forms.Plugin.Android/SvgImageRenderer.cs
@@ -10,91 +10,90 @@ using Android.Runtime;
 using NGraphics.Android.Custom;
 using NGraphics.Custom.Parsers;
 
-[assembly: ExportRenderer (typeof(SvgImage), typeof(SvgImageRenderer))]
+[assembly: ExportRenderer(typeof(SvgImage), typeof(SvgImageRenderer))]
 namespace SVG.Forms.Plugin.Droid
 {
     [Preserve(AllMembers = true)]
-    public class SvgImageRenderer : ViewRenderer<SvgImage,ImageView>
-	{
-		public static void Init ()
-		{
+    public class SvgImageRenderer : ViewRenderer<SvgImage, ImageView>
+    {
+        public static void Init()
+        {
             var temp = DateTime.Now;
         }
 
-        private SvgImage _formsControl {
-			get {
-				return Element as SvgImage;
-			}
-		}
-
-		protected override async void OnElementChanged (ElementChangedEventArgs<SvgImage> e)
-		{
-			base.OnElementChanged (e);
-
-		  if (_formsControl != null)
-		  {
-        await Task.Run(async () =>
+        private SvgImage _formsControl
         {
-          var svgStream = _formsControl.SvgAssembly.GetManifestResourceStream(_formsControl.SvgPath);
+            get { return Element as SvgImage; }
+        }
 
-          if (svgStream == null)
-          {
-            throw new Exception(string.Format("Error retrieving {0} make sure Build Action is Embedded Resource",
-              _formsControl.SvgPath));
-          }
-
-          var r = new SvgReader(new StreamReader(svgStream), new StylesParser(new ValuesParser()), new ValuesParser());
-
-          var graphics = r.Graphic;
-
-          var width = PixelToDP((int)_formsControl.WidthRequest <= 0 ? 100 : (int)_formsControl.WidthRequest);
-          var height = PixelToDP((int)_formsControl.HeightRequest <= 0 ? 100 : (int)_formsControl.HeightRequest);
-
-          var scale = 1.0;
-
-          if (height >= width)
-          {
-            scale = height / graphics.Size.Height;
-          }
-          else
-          {
-            scale = width / graphics.Size.Width;
-          }
-
-          var canvas = new AndroidPlatform().CreateImageCanvas(graphics.Size, scale);
-          graphics.Draw(canvas);
-          var image = (BitmapImage)canvas.GetImage();
-
-          return image;
-        }).ContinueWith(taskResult =>
+        protected override async void OnElementChanged(ElementChangedEventArgs<SvgImage> e)
         {
-          Device.BeginInvokeOnMainThread(() =>
-          {
-            var imageView = new ImageView(Context);
+            base.OnElementChanged(e);
 
-            imageView.SetScaleType(ImageView.ScaleType.FitXy);
-            imageView.SetImageBitmap(taskResult.Result.Bitmap);
+            if (_formsControl != null)
+            {
+                await Task.Run(async () =>
+                {
+                    var svgStream = _formsControl.SvgAssembly.GetManifestResourceStream(_formsControl.SvgPath);
 
-            SetNativeControl(imageView);
-          });
+                    if (svgStream == null)
+                    {
+                        throw new Exception(string.Format("Error retrieving {0} make sure Build Action is Embedded Resource",
+                  _formsControl.SvgPath));
+                    }
 
-        });
-		  }
-		}
+                    var r = new SvgReader(new StreamReader(svgStream), new StylesParser(new ValuesParser()), new ValuesParser());
 
-		public override SizeRequest GetDesiredSize (int widthConstraint, int heightConstraint)
-		{
-			return new SizeRequest (new Size (_formsControl.WidthRequest, _formsControl.WidthRequest));
-		}
+                    var graphics = r.Graphic;
 
-    /// <summary>
-    /// http://stackoverflow.com/questions/24465513/how-to-get-detect-screen-size-in-xamarin-forms
-    /// </summary>
-    /// <param name="pixel"></param>
-    /// <returns></returns>
-    private int PixelToDP(int pixel) {
-      var scale =Resources.DisplayMetrics.Density;
-      return (int) ((pixel * scale) + 0.5f);
+                    var width = PixelToDP((int)_formsControl.WidthRequest <= 0 ? 100 : (int)_formsControl.WidthRequest);
+                    var height = PixelToDP((int)_formsControl.HeightRequest <= 0 ? 100 : (int)_formsControl.HeightRequest);
+
+                    var scale = 1.0;
+
+                    if (height >= width)
+                    {
+                        scale = height / graphics.Size.Height;
+                    }
+                    else
+                    {
+                        scale = width / graphics.Size.Width;
+                    }
+
+                    var canvas = new AndroidPlatform().CreateImageCanvas(graphics.Size, scale);
+                    graphics.Draw(canvas);
+                    var image = (BitmapImage)canvas.GetImage();
+
+                    return image;
+                }).ContinueWith(taskResult =>
+                {
+                    Device.BeginInvokeOnMainThread(() =>
+                    {
+                        var imageView = new ImageView(Context);
+
+                        imageView.SetScaleType(ImageView.ScaleType.FitXy);
+                        imageView.SetImageBitmap(taskResult.Result.Bitmap);
+
+                        SetNativeControl(imageView);
+                    });
+                });
+            }
+        }
+
+        public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
+        {
+            return new SizeRequest(new Size(_formsControl.WidthRequest, _formsControl.WidthRequest));
+        }
+
+        /// <summary>
+        /// http://stackoverflow.com/questions/24465513/how-to-get-detect-screen-size-in-xamarin-forms
+        /// </summary>
+        /// <param name="pixel"></param>
+        /// <returns></returns>
+        private int PixelToDP(int pixel)
+        {
+            var scale = Resources.DisplayMetrics.Density;
+            return (int)((pixel * scale) + 0.5f);
+        }
     }
-	}
 }

--- a/SVG/SVG/SVG.Forms.Plugin.Android/SvgImageRenderer.cs
+++ b/SVG/SVG/SVG.Forms.Plugin.Android/SvgImageRenderer.cs
@@ -70,6 +70,17 @@ namespace SVG.Forms.Plugin.Droid
                 {
                     Device.BeginInvokeOnMainThread(() =>
                     {
+                        // PixelToDP can throw an ObjectDisposedException when the
+                        // renderer is disposed while loading and rendering the SVG
+                        // on the thread pool.
+                        var taskExceptions = taskResult.Exception?.InnerExceptions;
+                        if (taskExceptions != null &&
+                            taskExceptions.Count == 1 &&
+                            taskExceptions[0] is ObjectDisposedException)
+                        {
+                            return;
+                        }
+
                         // The renderer can already be disposed when we reach this block,
                         // e.g. when the SvgImage is removed from the view hierarchy
                         // immediately after being added.

--- a/SVG/SVG/SVG.Forms.Plugin.Android/SvgImageRenderer.cs
+++ b/SVG/SVG/SVG.Forms.Plugin.Android/SvgImageRenderer.cs
@@ -30,24 +30,25 @@ namespace SVG.Forms.Plugin.Droid
         {
             base.OnElementChanged(e);
 
-            if (_formsControl != null)
+            var formsControl = _formsControl;
+            if (formsControl != null)
             {
                 await Task.Run(async () =>
                 {
-                    var svgStream = _formsControl.SvgAssembly.GetManifestResourceStream(_formsControl.SvgPath);
+                    var svgStream = formsControl.SvgAssembly.GetManifestResourceStream(formsControl.SvgPath);
 
                     if (svgStream == null)
                     {
                         throw new Exception(string.Format("Error retrieving {0} make sure Build Action is Embedded Resource",
-                  _formsControl.SvgPath));
+                  formsControl.SvgPath));
                     }
 
                     var r = new SvgReader(new StreamReader(svgStream), new StylesParser(new ValuesParser()), new ValuesParser());
 
                     var graphics = r.Graphic;
 
-                    var width = PixelToDP((int)_formsControl.WidthRequest <= 0 ? 100 : (int)_formsControl.WidthRequest);
-                    var height = PixelToDP((int)_formsControl.HeightRequest <= 0 ? 100 : (int)_formsControl.HeightRequest);
+                    var width = PixelToDP((int)formsControl.WidthRequest <= 0 ? 100 : (int)formsControl.WidthRequest);
+                    var height = PixelToDP((int)formsControl.HeightRequest <= 0 ? 100 : (int)formsControl.HeightRequest);
 
                     var scale = 1.0;
 

--- a/SVG/SVG/SVG.Forms.Plugin.Android/SvgImageRenderer.cs
+++ b/SVG/SVG/SVG.Forms.Plugin.Android/SvgImageRenderer.cs
@@ -33,7 +33,7 @@ namespace SVG.Forms.Plugin.Droid
             var formsControl = _formsControl;
             if (formsControl != null)
             {
-                await Task.Run(async () =>
+                await Task.Run(() =>
                 {
                     var svgStream = formsControl.SvgAssembly.GetManifestResourceStream(formsControl.SvgPath);
 

--- a/SVG/SVG/SVG.Forms.Plugin.Android/SvgImageRenderer.cs
+++ b/SVG/SVG/SVG.Forms.Plugin.Android/SvgImageRenderer.cs
@@ -69,12 +69,21 @@ namespace SVG.Forms.Plugin.Droid
                 {
                     Device.BeginInvokeOnMainThread(() =>
                     {
-                        var imageView = new ImageView(Context);
+                        // The renderer can already be disposed when we reach this block,
+                        // e.g. when the SvgImage is removed from the view hierarchy
+                        // immediately after being added.
+                        try
+                        {
+                            var imageView = new ImageView(Context);
 
-                        imageView.SetScaleType(ImageView.ScaleType.FitXy);
-                        imageView.SetImageBitmap(taskResult.Result.Bitmap);
+                            imageView.SetScaleType(ImageView.ScaleType.FitXy);
+                            imageView.SetImageBitmap(taskResult.Result.Bitmap);
 
-                        SetNativeControl(imageView);
+                            SetNativeControl(imageView);
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                        }
                     });
                 });
             }


### PR DESCRIPTION
Fix crash due to disposed Android renderers by handling ObjectDisposedExceptions.